### PR TITLE
Update to 1.19.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,11 +2,11 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.19
-yarn_mappings=1.19+build.1
-loader_version=0.14.6
+minecraft_version=1.19.2
+yarn_mappings=1.19.2+build.28
+loader_version=0.14.10
 # Mod Properties
-mod_version=1.0.4
+mod_version=1.0.5
 maven_group=com.thecolonel63
 archives_base_name=serversidereplayrecorder
 # Dependencies

--- a/src/main/java/com/thecolonel63/serversidereplayrecorder/mixin/ClientConnectionMixin.java
+++ b/src/main/java/com/thecolonel63/serversidereplayrecorder/mixin/ClientConnectionMixin.java
@@ -1,10 +1,8 @@
 package com.thecolonel63.serversidereplayrecorder.mixin;
 
-import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.GenericFutureListener;
 import net.minecraft.network.ClientConnection;
 import net.minecraft.network.Packet;
-import org.jetbrains.annotations.Nullable;
+import net.minecraft.network.PacketCallbacks;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -14,8 +12,8 @@ import static com.thecolonel63.serversidereplayrecorder.server.ServerSideReplayR
 
 @Mixin(ClientConnection.class)
 public class ClientConnectionMixin {
-    @Inject(method = "send(Lnet/minecraft/network/Packet;Lio/netty/util/concurrent/GenericFutureListener;)V", at = @At("TAIL"))
-    private void sendPacketToClient(Packet<?> packet, @Nullable GenericFutureListener<? extends Future<? super Void>> callback, CallbackInfo ci) {
+    @Inject(method = "send(Lnet/minecraft/network/Packet;Lnet/minecraft/network/PacketCallbacks;)V", at = @At("TAIL"))
+    private void sendPacketToClient(Packet<?> packet, PacketCallbacks callbacks, CallbackInfo ci) {
 
         //Get the recorder instance dedicated to this connection and give it the packet to record.
         //If there is no recorder instance for this connection, don't do anything.

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,7 +24,7 @@
     "serversidereplayrecorder.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.13.2",
-    "minecraft": "1.19"
+    "fabricloader": ">=0.14.10",
+    "minecraft": "1.19.2"
   }
 }


### PR DESCRIPTION
Fixes the target of ClientConnectionMixin and bumps versions. An artifact can be found [here](https://github.com/Metroite/server-side-replay-recorder/releases/tag/v1.0.5).