### PR TITLE
update to 1.20.1

### DIFF
--- a/build-1.17.1.properties
+++ b/build-1.17.1.properties
@@ -1,0 +1,3 @@
+#Thu May 25 15:11:02 CEST 2023
+mod_version=1.1.5-mc1.17.1
+mod_buildnumber=1

--- a/build-1.20.properties
+++ b/build-1.20.properties
@@ -1,0 +1,3 @@
+#Wed Jun 07 18:58:53 CEST 2023
+mod_version=1.1.5-mc1.19.4
+mod_buildnumber=2

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,8 @@ dependencies {
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
     mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
-    modCompileOnly "carpet:fabric-carpet:${project.minecraft_version}-${project.carpet_core_version}"
+    //modCompileOnly "carpet:fabric-carpet:${project.minecraft_version}-${project.carpet_core_version}"
+    modCompileOnly "carpet:fabric-carpet:1.20-pre6-1.4.111+v230525"
     provided "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:latest.release"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@
 org.gradle.jvmargs=-Xmx4G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.20
-yarn_mappings=1.20+build.1
+minecraft_version=1.20.1
+yarn_mappings=1.20.1+build.1
 loader_version=0.14.21
 # Mod Properties
 mod_version=1.1.5-mc1.19.4

--- a/src/main/java/com/thecolonel63/serversidereplayrecorder/mixin/commands/CommandManagerMixin.java
+++ b/src/main/java/com/thecolonel63/serversidereplayrecorder/mixin/commands/CommandManagerMixin.java
@@ -18,7 +18,7 @@ public abstract class CommandManagerMixin {
     @Final
     private CommandDispatcher<ServerCommandSource> dispatcher;
 
-    @Inject(method = "<init>", at = @At(value = "INVOKE", target = "Lcom/mojang/brigadier/CommandDispatcher;setConsumer(Lcom/mojang/brigadier/ResultConsumer;)V", shift = At.Shift.BEFORE))
+    @Inject(method = "<init>", at = @At(value = "RETURN"))
     private void fabric_addCommands(CommandManager.RegistrationEnvironment environment, CommandRegistryAccess commandRegistryAccess, CallbackInfo ci) {
         if (environment.dedicated) {
             ReplayCommand cmd = new ReplayCommand();

--- a/src/main/java/com/thecolonel63/serversidereplayrecorder/util/FileHandlingUtility.java
+++ b/src/main/java/com/thecolonel63/serversidereplayrecorder/util/FileHandlingUtility.java
@@ -62,6 +62,7 @@ public class FileHandlingUtility {
 
     private static void zipFile(File file, ZipOutputStream zos) throws IOException {
         zos.putNextEntry(new ZipEntry(file.getName()));
+        new OutputStreamWriter(zos);
         BufferedInputStream bis = new BufferedInputStream(new FileInputStream(file));
         long bytesRead = 0;
         byte[] bytesIn = new byte[BUFFER_SIZE];


### PR DESCRIPTION
Carpet is still outdated so i used 1.20-pre6 as library ( should not impact anything as the class used is a API class so double will change )
Still we'll have to update the gradle.properties and build.gradle once carpet updates