### PR TITLE
Add Support for saving Region and Auto Loading Regions

### DIFF
--- a/build-1.20.properties
+++ b/build-1.20.properties
@@ -1,3 +1,3 @@
-#Sun Jul 02 02:18:12 CDT 2023
-mod_version=1.1.6-mc1.20
-mod_buildnumber=57
+#Sat Jul 01 17:45:07 CDT 2023
+mod_version=1.1.5-mc1.20
+mod_buildnumber=5

--- a/build-1.20.properties
+++ b/build-1.20.properties
@@ -1,3 +1,3 @@
-#Sat Jul 01 17:45:07 CDT 2023
-mod_version=1.1.5-mc1.20
-mod_buildnumber=5
+#Sun Jul 02 02:18:12 CDT 2023
+mod_version=1.1.6-mc1.20
+mod_buildnumber=57

--- a/src/main/java/com/thecolonel63/serversidereplayrecorder/ServerSideReplayRecorderServer.java
+++ b/src/main/java/com/thecolonel63/serversidereplayrecorder/ServerSideReplayRecorderServer.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactoryBuilder;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.thecolonel63.serversidereplayrecorder.config.MainConfig;
+import com.thecolonel63.serversidereplayrecorder.recorder.ReplayRecorder;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;

--- a/src/main/java/com/thecolonel63/serversidereplayrecorder/ServerSideReplayRecorderServer.java
+++ b/src/main/java/com/thecolonel63/serversidereplayrecorder/ServerSideReplayRecorderServer.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactoryBuilder;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.thecolonel63.serversidereplayrecorder.config.MainConfig;
-import com.thecolonel63.serversidereplayrecorder.recorder.ReplayRecorder;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;

--- a/src/main/java/com/thecolonel63/serversidereplayrecorder/config/MainConfig.java
+++ b/src/main/java/com/thecolonel63/serversidereplayrecorder/config/MainConfig.java
@@ -2,11 +2,14 @@ package com.thecolonel63.serversidereplayrecorder.config;
 
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.thecolonel63.serversidereplayrecorder.config.model.Region;
 
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 public class MainConfig {
@@ -24,6 +27,7 @@ public class MainConfig {
     private long  max_file_size = 10000000000L;
     private URL file_storage_url;
     private boolean debug = false;
+    private List<Region> regions = new ArrayList<>();
 
     public MainConfig() {
         try {
@@ -141,4 +145,13 @@ public class MainConfig {
     public void setRender_distance_fog_fix(boolean render_distance_fog_fix) {
         this.render_distance_fog_fix = render_distance_fog_fix;
     }
+
+    public List<Region> getRegions() {
+        return regions;
+    }
+
+    public void setRegions(List<Region> regions) {
+        this.regions = regions;
+    }
+
 }

--- a/src/main/java/com/thecolonel63/serversidereplayrecorder/config/model/Point.java
+++ b/src/main/java/com/thecolonel63/serversidereplayrecorder/config/model/Point.java
@@ -1,0 +1,39 @@
+package com.thecolonel63.serversidereplayrecorder.config.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.util.math.ChunkSectionPos;
+
+public class Point {
+
+    private int ChunkX;
+    private int ChunkZ;
+
+    public Point() {
+
+    }
+    public Point(int ChunkX, int ChunkZ) {
+        this.ChunkX = ChunkX;
+        this.ChunkZ = ChunkZ;
+    }
+
+    public int getChunkX() {
+        return ChunkX;
+    }
+
+    public ChunkPos toChunkPos(){
+        return new ChunkPos(ChunkSectionPos.getSectionCoord(ChunkX), ChunkSectionPos.getSectionCoord(ChunkZ));
+    }
+
+    public void setChunkX(int ChunkX) {
+        this.ChunkX = ChunkX;
+    }
+
+    public int getChunkZ() {
+        return ChunkZ;
+    }
+
+    public void setChunkZ(int ChunkZ) {
+        this.ChunkZ = ChunkZ;
+    }
+}

--- a/src/main/java/com/thecolonel63/serversidereplayrecorder/config/model/Region.java
+++ b/src/main/java/com/thecolonel63/serversidereplayrecorder/config/model/Region.java
@@ -1,0 +1,83 @@
+package com.thecolonel63.serversidereplayrecorder.config.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.thecolonel63.serversidereplayrecorder.ServerSideReplayRecorderServer;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.ColumnPos;
+
+import java.util.Iterator;
+
+public class Region {
+    private String name;
+    private Point to;
+    private Point from;
+    private boolean auto_record;
+    private String world;
+
+    public Region() {
+
+    }
+    public Region(String name, ColumnPos pos1, ColumnPos pos2, String world, boolean autoRecord) {
+        this.name = name;
+        this.to = new Point(pos1.x(), pos1.z());
+        this.from = new Point(pos2.x(), pos2.z());
+        this.auto_record = autoRecord;
+        this.world = world;
+        ServerSideReplayRecorderServer.server.getWorlds();
+
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Point getTo() {
+        return to;
+    }
+
+    public void setTo(Point to) {
+        this.to = to;
+    }
+
+
+    public String getWorld() {
+        return world;
+    }
+
+    public void setWorld(String world) {
+        this.world = world;
+    }
+    @JsonIgnore
+    public ServerWorld toServerWorld(){
+        Iterator<ServerWorld> it = ServerSideReplayRecorderServer.server.getWorlds().iterator();
+        while(it.hasNext()) {
+            ServerWorld sw = it.next();
+            if(!(sw.toString().equals(this.world))) continue;
+            return sw;
+        }
+        return null;
+    }
+
+    public Point getFrom() {
+        return from;
+    }
+
+    public void setFrom(Point from) {
+        this.from = from;
+    }
+
+    @JsonProperty("autoRecord")
+    public boolean isAutoRecord() {
+        return auto_record;
+    }
+
+    public void setAutoRecord(boolean auto_record) {
+        this.auto_record = auto_record;
+    }
+
+}

--- a/src/main/java/com/thecolonel63/serversidereplayrecorder/mixin/main/MinecraftServerMixin.java
+++ b/src/main/java/com/thecolonel63/serversidereplayrecorder/mixin/main/MinecraftServerMixin.java
@@ -10,9 +10,6 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import java.util.Iterator;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.BooleanSupplier;
 
 @Mixin(MinecraftServer.class)


### PR DESCRIPTION
Add support so when users add a region by command it will save it to config and will allow them to autoload it on startup. 

Example of what it adds to config:

```
regions:
  - name: "test"
    to:
      chunkZ: -100
      chunkX: -100
    from:
      chunkZ: 100
      chunkX: 100
    world: "ServerLevel[world]"
    autoRecord: false
```
    
    
While doing this I learned 2 regions cannot be overlapping if not it can cause issues and crash the server (Tested with the official jar to make sure) and you can make regions in unloaded chunks and if you tp to them you crash your server. I also ran into issue #30 when you have 2 or more regions and trying to shutdown the server it will save one but nothing else and crash